### PR TITLE
#16 feat: 일정 - 유저 관계 매핑 및 일부 로직 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -10,6 +10,8 @@ import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -27,8 +29,8 @@ public class EventController {
     @Operation(summary = "일정 생성", description = "관리자가 일정을 등록합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
-    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent) {
-        eventService.createEvent(requestEvent);
+    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent, @AuthenticationPrincipal User user) {
+        eventService.createEvent(requestEvent, user.getUsername());
         return CommonResponse.createSuccess(EVENT_CREATED_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -50,7 +50,7 @@ public class EventController {
     @GetMapping("")
     public CommonResponse<List<ResponseEvent>> getEvents(
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-            @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+            @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) throws BusinessLogicException {
 
         List<ResponseEvent> responseEvents = eventService.getEventsBetweenDate(startDate, endDate);
         return CommonResponse.createSuccess(responseEvents);

--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import leets.weeth.domain.event.dto.RequestEvent;
 import leets.weeth.domain.event.dto.ResponseEvent;
 import leets.weeth.domain.event.service.EventService;
-import leets.weeth.global.common.exception.BusinessLogicException;
+import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.event.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import leets.weeth.domain.event.dto.RequestEvent;
 import leets.weeth.domain.event.dto.ResponseEvent;
 import leets.weeth.domain.event.service.EventService;
@@ -26,7 +27,7 @@ public class EventController {
     @Operation(summary = "일정 생성", description = "관리자가 일정을 등록합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
-    public CommonResponse<String> createEvent(@RequestBody RequestEvent requestEvent) {
+    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent) {
         eventService.createEvent(requestEvent);
         return CommonResponse.createSuccess(EVENT_CREATED_SUCCESS.getMessage());
     }

--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -30,7 +30,7 @@ public class EventController {
     @Operation(summary = "일정 생성", description = "관리자가 일정을 등록합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
-    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent, @AuthenticationPrincipal User user) {
+    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent, @AuthenticationPrincipal User user) throws BusinessLogicException {
         eventService.createEvent(requestEvent, user.getUsername());
         return CommonResponse.createSuccess(EVENT_CREATED_SUCCESS.getMessage());
     }

--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import leets.weeth.domain.event.dto.RequestEvent;
 import leets.weeth.domain.event.dto.ResponseEvent;
 import leets.weeth.domain.event.service.EventService;
+import leets.weeth.global.common.exception.BusinessLogicException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -59,8 +60,8 @@ public class EventController {
     @Operation(summary = "일정 수정", description = "관리자가 일정을 수정합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PatchMapping("/{id}")
-    public CommonResponse<String> updateEvent(@PathVariable Long id, @RequestBody RequestEvent requestEvent) {
-        eventService.updateEvent(id, requestEvent);
+    public CommonResponse<String> updateEvent(@PathVariable Long id, @RequestBody RequestEvent requestEvent, @AuthenticationPrincipal User user) throws BusinessLogicException {
+        eventService.updateEvent(id, requestEvent, user.getUsername());
         return CommonResponse.createSuccess(EVENT_UPDATED_SUCCESS.getMessage());
     }
 
@@ -68,8 +69,8 @@ public class EventController {
     @Operation(summary = "일정 삭제", description = "관리자가 일정을 삭제합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
-    public CommonResponse<String> deleteEvent(@PathVariable Long id) {
-        eventService.deleteEvent(id);
+    public CommonResponse<String> deleteEvent(@PathVariable Long id, @AuthenticationPrincipal User user) throws BusinessLogicException {
+        eventService.deleteEvent(id, user.getUsername());
         return CommonResponse.createSuccess(EVENT_DELETED_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/event/dto/RequestEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/RequestEvent.java
@@ -2,9 +2,11 @@ package leets.weeth.domain.event.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
+@Builder
 public record RequestEvent (
      @NotBlank String title,
      @NotBlank String content,

--- a/src/main/java/leets/weeth/domain/event/dto/RequestEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/RequestEvent.java
@@ -11,7 +11,6 @@ public record RequestEvent (
      @NotBlank String title,
      @NotBlank String content,
      String location,
-     @NotNull boolean isAllDay,
      @NotNull LocalDateTime startDateTime,
      @NotNull LocalDateTime endDateTime
 ) {}

--- a/src/main/java/leets/weeth/domain/event/dto/RequestEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/RequestEvent.java
@@ -1,13 +1,15 @@
 package leets.weeth.domain.event.dto;
 
-import lombok.Getter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
 public record RequestEvent (
-     String title,
-     String content,
+     @NotBlank String title,
+     @NotBlank String content,
      String location,
-     LocalDateTime startDateTime,
-     LocalDateTime endDateTime
+     @NotNull boolean isAllDay,
+     @NotNull LocalDateTime startDateTime,
+     @NotNull LocalDateTime endDateTime
 ) {}

--- a/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
@@ -11,7 +11,6 @@ public record ResponseEvent (
         String title,
         String content,
         String location,
-        boolean isAllDay,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime
 ) {}

--- a/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
@@ -1,8 +1,6 @@
 package leets.weeth.domain.event.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 
@@ -13,6 +11,7 @@ public record ResponseEvent (
         String title,
         String content,
         String location,
+        boolean isAllDay,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime
 ) {}

--- a/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
@@ -12,5 +12,6 @@ public record ResponseEvent (
         String content,
         String location,
         LocalDateTime startDateTime,
-        LocalDateTime endDateTime
+        LocalDateTime endDateTime,
+        String userName
 ) {}

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -27,8 +27,6 @@ public class Event extends BaseEntity {
 
     private String location;
 
-    private Boolean isAllDay;
-
     private LocalDateTime startDateTime;
 
     private LocalDateTime endDateTime;
@@ -38,7 +36,6 @@ public class Event extends BaseEntity {
         Optional.ofNullable(dto.title()).ifPresent(title -> this.title = title);
         Optional.ofNullable(dto.content()).ifPresent(content -> this.content = content);
         Optional.ofNullable(dto.location()).ifPresent(location -> this.location = location);
-        Optional.of(dto.isAllDay()).ifPresent(isAllDay -> this.isAllDay = isAllDay);// boolean으로 가져오기 때문에 null을 허용하지 않음
         Optional.ofNullable(dto.startDateTime()).ifPresent(startDateTime -> this.startDateTime = startDateTime);
         Optional.ofNullable(dto.endDateTime()).ifPresent(endDateTime -> this.endDateTime = endDateTime);
     }

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.event.entity;
 
 import jakarta.persistence.*;
 import leets.weeth.domain.event.dto.RequestEvent;
+import leets.weeth.domain.user.entity.User;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.*;
 
@@ -30,6 +31,21 @@ public class Event extends BaseEntity {
     private LocalDateTime startDateTime;
 
     private LocalDateTime endDateTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    // 정적 팩토리 메서드
+    public static Event fromDto(RequestEvent dto, User user) {
+        return Event.builder()
+                .title(dto.title())
+                .content(dto.content())
+                .location(dto.location())
+                .startDateTime(dto.startDateTime())
+                .endDateTime(dto.endDateTime())
+                .user(user).build();
+    }
 
     // 일정 수정을 위한 메소드
     public void updateFromDto(RequestEvent dto) {

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -32,10 +32,6 @@ public class Event extends BaseEntity {
     private LocalDateTime startDateTime;
 
     private LocalDateTime endDateTime;
-//
-//    @ManyToOne
-//    @JoinColumn(name = "user_id", nullable = false)
-//    private User user;
 
     // 일정 수정을 위한 메소드
     public void updateFromDto(RequestEvent dto) {

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -27,15 +27,22 @@ public class Event extends BaseEntity {
 
     private String location;
 
+    private Boolean isAllDay;
+
     private LocalDateTime startDateTime;
 
     private LocalDateTime endDateTime;
+//
+//    @ManyToOne
+//    @JoinColumn(name = "user_id", nullable = false)
+//    private User user;
 
     // 일정 수정을 위한 메소드
     public void updateFromDto(RequestEvent dto) {
         Optional.ofNullable(dto.title()).ifPresent(title -> this.title = title);
         Optional.ofNullable(dto.content()).ifPresent(content -> this.content = content);
         Optional.ofNullable(dto.location()).ifPresent(location -> this.location = location);
+        Optional.of(dto.isAllDay()).ifPresent(isAllDay -> this.isAllDay = isAllDay);// boolean으로 가져오기 때문에 null을 허용하지 않음
         Optional.ofNullable(dto.startDateTime()).ifPresent(startDateTime -> this.startDateTime = startDateTime);
         Optional.ofNullable(dto.endDateTime()).ifPresent(endDateTime -> this.endDateTime = endDateTime);
     }

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -33,7 +33,7 @@ public class Event extends BaseEntity {
     private LocalDateTime endDateTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id")
+    @JoinColumn(name="user_id", nullable=false)
     private User user;
 
     // 정적 팩토리 메서드

--- a/src/main/java/leets/weeth/domain/event/entity/enums/ErrorMessage.java
+++ b/src/main/java/leets/weeth/domain/event/entity/enums/ErrorMessage.java
@@ -9,6 +9,7 @@ public enum ErrorMessage {
 
     EVENT_NOT_FOUND("id에 해당하는 일정이 존재하지 않습니다."),
     USER_NOT_FOUND("존재하지 않는 사용자입니다."),
-    USER_NOT_MATCH("일정과 사용자가 일치하지 않습니다.");
+    USER_NOT_MATCH("일정과 사용자가 일치하지 않습니다."),
+    INVALID_DATE("입력한 기간이 올바르지 않습니다.");
     private final String message;
 }

--- a/src/main/java/leets/weeth/domain/event/entity/enums/ErrorMessage.java
+++ b/src/main/java/leets/weeth/domain/event/entity/enums/ErrorMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 public enum ErrorMessage {
 
-    EVENT_NOT_FOUND("id에 해당하는 일정이 존재하지 않습니다.");
-
+    EVENT_NOT_FOUND("id에 해당하는 일정이 존재하지 않습니다."),
+    USER_NOT_FOUND("존재하지 않는 사용자입니다."),
+    USER_NOT_MATCH("일정과 사용자가 일치하지 않습니다.");
     private final String message;
 }

--- a/src/main/java/leets/weeth/domain/event/mapper/EventMapper.java
+++ b/src/main/java/leets/weeth/domain/event/mapper/EventMapper.java
@@ -10,7 +10,7 @@ import org.mapstruct.factory.Mappers;
 public interface EventMapper {
     EventMapper INSTANCE = Mappers.getMapper(EventMapper.class);
 
-    Event fromDto(RequestEvent requestEvent);
+//    Event fromDto(RequestEvent requestEvent);
 
     ResponseEvent toDto(Event event);
 }

--- a/src/main/java/leets/weeth/domain/event/mapper/EventMapper.java
+++ b/src/main/java/leets/weeth/domain/event/mapper/EventMapper.java
@@ -4,6 +4,7 @@ import leets.weeth.domain.event.dto.RequestEvent;
 import leets.weeth.domain.event.dto.ResponseEvent;
 import leets.weeth.domain.event.entity.Event;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
@@ -12,5 +13,7 @@ public interface EventMapper {
 
 //    Event fromDto(RequestEvent requestEvent);
 
+    @Mapping(source = "user.name", target = "userName") // User 객체의 name 필드를 userName 필드로 매핑
     ResponseEvent toDto(Event event);
+
 }

--- a/src/main/java/leets/weeth/domain/event/repository/EventRepository.java
+++ b/src/main/java/leets/weeth/domain/event/repository/EventRepository.java
@@ -11,4 +11,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findByStartDateTimeBetween(LocalDateTime startDate, LocalDateTime endDate);
 
+    void deleteByIdAndUserId(Long id, Long userId);
+
+    // 유저가 작성한 일정 리스트 반환. 필요하다면 사용
+//    Optional<Event> findByIdAndUserId(Long eventId, Long userId);
 }

--- a/src/main/java/leets/weeth/domain/event/repository/EventRepository.java
+++ b/src/main/java/leets/weeth/domain/event/repository/EventRepository.java
@@ -11,8 +11,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findByStartDateTimeBetween(LocalDateTime startDate, LocalDateTime endDate);
 
-    void deleteByIdAndUserId(Long id, Long userId);
-
     // 유저가 작성한 일정 리스트 반환. 필요하다면 사용
 //    Optional<Event> findByIdAndUserId(Long eventId, Long userId);
 }

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -67,6 +67,7 @@ public class EventService {
     }
 
     // 일정 삭제
+    @Transactional
     public void deleteEvent(Long eventId, String userEmail) throws BusinessLogicException {
 
         Event oldEvent = eventRepository.findById(eventId)

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -8,7 +8,7 @@ import leets.weeth.domain.event.mapper.EventMapper;
 import leets.weeth.domain.event.repository.EventRepository;
 import leets.weeth.domain.user.entity.User;
 import leets.weeth.domain.user.repository.UserRepository;
-import leets.weeth.global.common.exception.BusinessLogicException;
+import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -6,7 +6,10 @@ import leets.weeth.domain.event.dto.ResponseEvent;
 import leets.weeth.domain.event.entity.Event;
 import leets.weeth.domain.event.mapper.EventMapper;
 import leets.weeth.domain.event.repository.EventRepository;
+import leets.weeth.domain.user.entity.User;
+import leets.weeth.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,16 +20,21 @@ import static leets.weeth.domain.event.entity.enums.ErrorMessage.EVENT_NOT_FOUND
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EventService {
     private final EventRepository eventRepository;
+
+    private final UserRepository userRepository;
 
     private final EventMapper eventMapper;
 
     // 일정 생성
     @Transactional
-    public void createEvent(RequestEvent requestEvent) {
-        Event event = eventMapper.fromDto(requestEvent);
-        eventRepository.save(event);
+    public void createEvent(RequestEvent requestEvent, String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+        // 유저 정보 저장을 위해 매퍼를 제거하고 정적 팩토리 메서드 사용
+        eventRepository.save(Event.fromDto(requestEvent, user));
     }
 
     // 일정 상세 조회

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -10,7 +10,6 @@ import leets.weeth.domain.user.entity.User;
 import leets.weeth.domain.user.repository.UserRepository;
 import leets.weeth.global.common.exception.BusinessLogicException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +18,7 @@ import java.util.List;
 
 import static leets.weeth.domain.event.entity.enums.ErrorMessage.*;
 
-@Slf4j
+
 @Service
 @RequiredArgsConstructor
 public class EventService {
@@ -31,7 +30,10 @@ public class EventService {
 
     // 일정 생성
     @Transactional
-    public void createEvent(RequestEvent requestEvent, String userEmail) {
+    public void createEvent(RequestEvent requestEvent, String userEmail) throws BusinessLogicException {
+        // 기간 입력 검증
+        validateDateRange(requestEvent.startDateTime(), requestEvent.endDateTime());
+
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND.getMessage()));
         // 유저 정보 저장을 위해 매퍼를 제거하고 정적 팩토리 메서드 사용
@@ -49,9 +51,9 @@ public class EventService {
     // 기간 별 일정 조회
     @Transactional(readOnly = true)
     public List<ResponseEvent> getEventsBetweenDate(LocalDateTime startDate, LocalDateTime endDate) throws BusinessLogicException {
-        if(startDate.isAfter(endDate)) {
-            throw new BusinessLogicException(INVALID_DATE.getMessage());
-        }
+        // 기간 입력 검증
+        validateDateRange(startDate, endDate);
+
         List<Event> events = eventRepository.findByStartDateTimeBetween(startDate, endDate);
         return events.stream()
                 .map(eventMapper::toDto)
@@ -61,18 +63,21 @@ public class EventService {
     // 일정 수정
     @Transactional
     public void updateEvent(Long eventId, RequestEvent updatedEvent, String userEmail) throws BusinessLogicException {
-        Event oldEvent = checkEventUserValidation(eventId, userEmail);
-        oldEvent.updateFromDto(updatedEvent); //실제 객체가 필요
+        // 일정을 생성한 사용자인지 확인
+        Event oldEvent = validateEventOwner(eventId, userEmail);
+        oldEvent.updateFromDto(updatedEvent);
     }
 
     // 일정 삭제
     @Transactional
     public void deleteEvent(Long eventId, String userEmail) throws BusinessLogicException {
-        Event oldEvent = checkEventUserValidation(eventId, userEmail);
+        // 일정을 생성한 사용자인지 확인
+        Event oldEvent = validateEventOwner(eventId, userEmail);
         eventRepository.delete(oldEvent);
     }
 
-    private Event checkEventUserValidation(Long eventId, String userEmail) throws BusinessLogicException {
+    // 해당 일정을 생성한 사용자와 같은지 검증
+    private Event validateEventOwner(Long eventId, String userEmail) throws BusinessLogicException {
         Event oldEvent = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EntityNotFoundException(EVENT_NOT_FOUND.getMessage()));
 
@@ -84,5 +89,12 @@ public class EventService {
             throw new BusinessLogicException(USER_NOT_MATCH.getMessage());
         }
         return oldEvent;
+    }
+
+    // 시작 날짜가 종료 날짜 보다 느린지 검증
+    private void validateDateRange(LocalDateTime start, LocalDateTime end) throws BusinessLogicException {
+        if (start.isAfter(end)) {
+            throw new BusinessLogicException(INVALID_DATE.getMessage());
+        }
     }
 }

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -48,7 +48,10 @@ public class EventService {
 
     // 기간 별 일정 조회
     @Transactional(readOnly = true)
-    public List<ResponseEvent> getEventsBetweenDate(LocalDateTime startDate, LocalDateTime endDate) {
+    public List<ResponseEvent> getEventsBetweenDate(LocalDateTime startDate, LocalDateTime endDate) throws BusinessLogicException {
+        if(startDate.isAfter(endDate)) {
+            throw new BusinessLogicException(INVALID_DATE.getMessage());
+        }
         List<Event> events = eventRepository.findByStartDateTimeBetween(startDate, endDate);
         return events.stream()
                 .map(eventMapper::toDto)

--- a/src/main/java/leets/weeth/domain/user/controller/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/controller/UserController.java
@@ -3,7 +3,7 @@ package leets.weeth.domain.user.controller;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.dto.UserDTO;
 import leets.weeth.domain.user.service.UserService;
-import leets.weeth.global.common.exception.BusinessLogicException;
+import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/leets/weeth/domain/user/service/UserService.java
+++ b/src/main/java/leets/weeth/domain/user/service/UserService.java
@@ -7,7 +7,7 @@ import leets.weeth.domain.user.entity.User;
 import leets.weeth.domain.user.entity.enums.Status;
 import leets.weeth.domain.user.mapper.UserMapper;
 import leets.weeth.domain.user.repository.UserRepository;
-import leets.weeth.global.common.exception.BusinessLogicException;
+import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/leets/weeth/global/common/error/CommonExceptionController.java
+++ b/src/main/java/leets/weeth/global/common/error/CommonExceptionController.java
@@ -1,5 +1,6 @@
-package leets.weeth.global.common.exception;
+package leets.weeth.global.common.error;
 
+import leets.weeth.global.common.error.exception.ExceptionType;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindException;

--- a/src/main/java/leets/weeth/global/common/error/exception/ExceptionType.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/ExceptionType.java
@@ -1,7 +1,8 @@
-package leets.weeth.global.common.exception;
+package leets.weeth.global.common.error.exception;
 
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
+import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/BusinessLogicException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/BusinessLogicException.java
@@ -1,4 +1,4 @@
-package leets.weeth.global.common.exception;
+package leets.weeth.global.common.error.exception.custom;
 
 public class BusinessLogicException extends Exception {
     public BusinessLogicException(String message) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   profiles:
     active: local
+
+springdoc:
+  swagger-ui:
+    operations-sorter: method
+    tags-sorter: alpha


### PR DESCRIPTION
## 1. 개발내용
✅ 일정 테이블에 유저 정보 저장
✅ 유저 정보 저장을 위한 정적 팩토리 메소드 구현
✅ 유저 정보 저장과 검증을 위한 컨트롤러, 서비스 로직 수정
✅ 응답시 사용자 이름을 함께 반환하기 위해 RequestDto, EventMapper 수정
✅ 스웨거 API 정렬
## 2. 구현 세부사항
- @AuthenticationPrincipal을 이용해 생성, 수정, 삭제 요청시 로그인된 사용자의 정보를 확인하여 함께 저장하고, 생성한 유저만 수정, 삭제 할 수 있도록 로직 변경하였습니다
- 유저 정보를 함께 저장하려다 보니 dto -> event로 변환해주는 mapper 사용이 제한되는 부분(dto에 유저정보를 넣고 매핑하기, dto를 event로 매핑하고 setUser하기)이 있어 mapper 사용을 하지 않고 Event 엔티티 안에 정적 팩토리 메서드를 정의하는 쪽으로 수정하였음
- 유저 정보를 수정할 일은 없을 거 같아 updateFromDto 관련해서는 수정하지 않았음
- EventRepository에 이벤트 ID와 유저 ID를 통해 삭제하는 메서드를 정의하였음
## 3. 메모
- 하루종일 옵션을 구현 했다가 다시 삭제했습니당
- 수정과 삭제시 이벤트에 저장된 유저 ID와 현재 로그인된 유저 ID를 비교해 검증하는 로직을 짜봤는데 더 나은 방법이 있다면 알려주세요!!
## 4. 출력결과
<details>
<summary>스웨거 로그인</summary>
<img width="1137" alt="image" src=https://github.com/Leets-Official/Weeth-BE/assets/77369759/4c907f6b-95d2-4876-bed3-0c2db2a9f39f>
</details>

<details>
<summary>조회 결과</summary>
<img width="1137" alt="image" src=https://github.com/Leets-Official/Weeth-BE/assets/77369759/2ee5b831-7f49-4655-97b2-57e68d21b527>
</details>

<details>
<summary>다른 유저가 조작시 결과</summary>
<img width="1137" alt="image" src=https://github.com/Leets-Official/Weeth-BE/assets/77369759/babefe24-a64e-4146-a188-8be784e4bae0>
<img width="1137" alt="image" src=https://github.com/Leets-Official/Weeth-BE/assets/77369759/da173592-f1aa-44e9-8f08-4d3a3b096f89>
</details>