### PR TITLE
Feature-#26

### DIFF
--- a/src/main/java/leets/weeth/domain/user/controller/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.dto.UserDTO;
 import leets.weeth.domain.user.service.UserService;
@@ -9,6 +10,9 @@ import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -16,21 +20,30 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "동아리 가입 신청")
     @PostMapping("/apply")
     public CommonResponse<String> apply(@RequestBody @Valid UserDTO.SignUp requestDto) {
         userService.signUp(requestDto);
         return CommonResponse.createSuccess();
     }
 
+    @Operation(summary = "동아리 탈퇴")
     @DeleteMapping("")
     public CommonResponse<String> delete(@CurrentUser Long userId) {
         userService.delete(userId);
         return CommonResponse.createSuccess();
     }
 
+    @Operation(summary = "동아리 OB 지원")
     @PostMapping("/apply/{cardinal}")
     public CommonResponse<String> applyOB(@CurrentUser Long userId, @PathVariable Integer cardinal) throws BusinessLogicException {
         userService.applyOB(userId, cardinal);
         return CommonResponse.createSuccess();
+    }
+
+    @Operation(summary = "동아리 회원 조회 (전체/기수별)")
+    @GetMapping("/all")
+    public CommonResponse<Map<Integer, List<UserDTO.Response>>> getUsers() {
+        return CommonResponse.createSuccess(userService.findUsers());
     }
 }

--- a/src/main/java/leets/weeth/domain/user/controller/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.weeth.domain.user.dto.UserDTO;
 import leets.weeth.domain.user.service.UserService;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+@Tag(name = "UserController", description = "사용자 관련 컨트롤러")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")

--- a/src/main/java/leets/weeth/domain/user/dto/UserDTO.java
+++ b/src/main/java/leets/weeth/domain/user/dto/UserDTO.java
@@ -5,23 +5,27 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.user.entity.enums.Department;
 import leets.weeth.domain.user.entity.enums.Position;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class UserDTO {
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SignUp {
-        @NotBlank        private String name;
-        @Email @NotBlank private String email;
-        @NotBlank        private String password;
-        @NotBlank        private String studentId;
-        @NotBlank        private String phoneNumber;
-        @NotNull         private Position position;
-        @NotNull         private Department department;
-        @NotNull         private Integer cardinal;
-    }
+    public record SignUp (
+        @NotBlank        String name,
+        @Email @NotBlank String email,
+        @NotBlank        String password,
+        @NotBlank        String studentId,
+        @NotBlank        String phoneNumber,
+        @NotNull         Position position,
+        @NotNull         Department department,
+        @NotNull         Integer cardinal
+    ) {}
+
+    public record Response(
+            Integer id,
+            String name,
+            String studentId,
+            Department department,
+            String email,
+            Integer cardinal,
+            Position position
+    ) {}
 }

--- a/src/main/java/leets/weeth/domain/user/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/mapper/UserMapper.java
@@ -3,19 +3,17 @@ package leets.weeth.domain.user.mapper;
 import leets.weeth.domain.user.dto.UserDTO;
 import leets.weeth.domain.user.entity.User;
 import org.mapstruct.*;
-import org.mapstruct.factory.Mappers;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserMapper {
-
-    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
-
     // 수정: 모든 mapper 어노테이션 매핑 최소화
     @Mappings({
-            @Mapping(target = "cardinals", expression = "java( java.util.List.of(dto.getCardinal()) )"),
-            @Mapping(target = "password", expression = "java( passwordEncoder.encode(dto.getPassword()) )")
+            @Mapping(target = "cardinals", expression = "java( java.util.List.of(dto.cardinal()) )"),
+            @Mapping(target = "password", expression = "java( passwordEncoder.encode(dto.password()) )")
     })
     User from(UserDTO.SignUp dto, @Context PasswordEncoder passwordEncoder);
+
+    UserDTO.Response to(User user);
 }
 

--- a/src/main/java/leets/weeth/domain/user/repository/UserRepository.java
+++ b/src/main/java/leets/weeth/domain/user/repository/UserRepository.java
@@ -1,13 +1,17 @@
 package leets.weeth.domain.user.repository;
 
 import leets.weeth.domain.user.entity.User;
+import leets.weeth.domain.user.entity.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    List<User> findAllByStatusOrderByName(Status status);
 
     Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/leets/weeth/domain/user/service/UserService.java
+++ b/src/main/java/leets/weeth/domain/user/service/UserService.java
@@ -1,29 +1,38 @@
 package leets.weeth.domain.user.service;
 
-import jakarta.persistence.EntityExistsException;
-import jakarta.persistence.EntityNotFoundException;
 import leets.weeth.domain.user.dto.UserDTO;
 import leets.weeth.domain.user.entity.User;
-import leets.weeth.domain.user.entity.enums.Status;
 import leets.weeth.domain.user.mapper.UserMapper;
 import leets.weeth.domain.user.repository.UserRepository;
 import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
+import leets.weeth.global.common.error.exception.custom.InvalidAccessException;
+import leets.weeth.global.common.error.exception.custom.UserExistsException;
+import leets.weeth.global.common.error.exception.custom.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.AbstractMap;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static leets.weeth.domain.user.entity.enums.Status.ACTIVE;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
-    private final UserMapper mapper = UserMapper.INSTANCE;
+    private final UserMapper mapper;
     private final PasswordEncoder passwordEncoder;
 
     public void signUp(UserDTO.SignUp requestDto) {
-        if (userRepository.findByEmail(requestDto.getEmail()).isPresent())
-            throw new EntityExistsException("이미 존재하는 아이디입니다.");
+        if (userRepository.findByEmail(requestDto.email()).isPresent())
+            throw new UserExistsException();
 
         // 수정: 아이디 이외 중복 처리
 
@@ -40,12 +49,24 @@ public class UserService {
     @Transactional
     public void applyOB(Long userId, Integer cardinal) throws BusinessLogicException {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+                .orElseThrow(UserNotFoundException::new);
 
-        if(!user.getStatus().equals(Status.ACTIVE))
-            throw new BusinessLogicException("올바르지 않은 접근입니다.");
+        if(!user.getStatus().equals(ACTIVE))
+            throw new InvalidAccessException();
 
         user.applyOB(cardinal);
     }
 
+    public Map<Integer, List<UserDTO.Response>> findUsers() {
+        return userRepository.findAll().stream()
+                .filter(user -> user.getStatus() == ACTIVE)
+                .sorted(Comparator.comparing(User::getName))    // 이름으로 정렬
+                .flatMap(user -> Stream.concat(
+                        user.getCardinals().stream()
+                                .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map
+                        Stream.of(new AbstractMap.SimpleEntry<>(0, mapper.to(user)))    // 모든 기수는 cardinal 0에 저장
+                ))
+                .collect(Collectors.groupingBy(Map.Entry::getKey,   // key = 기수, value = 유저 정보
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+    }
 }

--- a/src/main/java/leets/weeth/domain/user/service/UserService.java
+++ b/src/main/java/leets/weeth/domain/user/service/UserService.java
@@ -5,8 +5,8 @@ import leets.weeth.domain.user.entity.User;
 import leets.weeth.domain.user.mapper.UserMapper;
 import leets.weeth.domain.user.repository.UserRepository;
 import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
+import leets.weeth.global.common.error.exception.custom.EmailExistsException;
 import leets.weeth.global.common.error.exception.custom.InvalidAccessException;
-import leets.weeth.global.common.error.exception.custom.UserExistsException;
 import leets.weeth.global.common.error.exception.custom.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -32,7 +32,7 @@ public class UserService {
 
     public void signUp(UserDTO.SignUp requestDto) {
         if (userRepository.findByEmail(requestDto.email()).isPresent())
-            throw new UserExistsException();
+            throw new EmailExistsException();
 
         // 수정: 아이디 이외 중복 처리
 

--- a/src/main/java/leets/weeth/domain/user/service/UserService.java
+++ b/src/main/java/leets/weeth/domain/user/service/UserService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.AbstractMap;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -58,9 +57,7 @@ public class UserService {
     }
 
     public Map<Integer, List<UserDTO.Response>> findUsers() {
-        return userRepository.findAll().stream()
-                .filter(user -> user.getStatus() == ACTIVE)
-                .sorted(Comparator.comparing(User::getName))    // 이름으로 정렬
+        return userRepository.findAllByStatusOrderByName(ACTIVE).stream()
                 .flatMap(user -> Stream.concat(
                         user.getCardinals().stream()
                                 .map(cardinal -> new AbstractMap.SimpleEntry<>(cardinal, mapper.to(user))), // 기수별 Map

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/EmailExistsException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/EmailExistsException.java
@@ -1,0 +1,9 @@
+package leets.weeth.global.common.error.exception.custom;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class EmailExistsException extends EntityNotFoundException {
+    public EmailExistsException() {
+        super("이미 사용 중인 이메일입니다.");
+    }
+}

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/InvalidAccessException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/InvalidAccessException.java
@@ -1,0 +1,7 @@
+package leets.weeth.global.common.error.exception.custom;
+
+public class InvalidAccessException extends BusinessLogicException {
+    public InvalidAccessException() {
+        super("잘못된 접근입니다.");
+    }
+}

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/UserExistsException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/UserExistsException.java
@@ -1,0 +1,9 @@
+package leets.weeth.global.common.error.exception.custom;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class UserExistsException extends EntityNotFoundException {
+    public UserExistsException() {
+        super("존재하지 않는 유저입니다.");
+    }
+}

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/UserExistsException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/UserExistsException.java
@@ -1,9 +1,0 @@
-package leets.weeth.global.common.error.exception.custom;
-
-import jakarta.persistence.EntityNotFoundException;
-
-public class UserExistsException extends EntityNotFoundException {
-    public UserExistsException() {
-        super("존재하지 않는 유저입니다.");
-    }
-}

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/UserNotFoundException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.weeth.global.common.error.exception.custom;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class UserNotFoundException extends EntityNotFoundException {
+    public UserNotFoundException() {
+        super("존재하지 않는 유저입니다.");
+    }
+}


### PR DESCRIPTION
## 1. 개발내용
1. 가입된 동아리원 조회 기능 추가
2. dto class -> record
3. mapper 스프링 빈 등록
4. exception 구체화
5. 스웨거 summary 등록

## 2. 구현 세부사항
멤버들을 전체 조회하지만 기수별로도 조회하므로 리스트를 정렬만 된 상태로 통으로 넘겨주는게 오버헤드가 더 적을지, 아니면 여기서 groupingBy해서 넘겨주는게 오버헤드가 더 적을지 고민이었습니다.
후자를 선택했을 때 데이터 자체는 중복되므로 response가 무거워지긴 하지만 어차피 페이지에 들어오고 새로고침을 하지 않는 이상 한 번만 요청을 하므로, 프론트에서 기수를 선택할 때마다 전체 데이터에서 필터링을 하기보다 프론트에서 연산을 생략할 수 있도록 주는 족족 바로 가져다 쓸 수 있는 상태가 더 오버헤드가 적을 것 같다고 생각했습니다.
그리고 Map<Integer, List<UserDTO.Response>>와 페이지네이션 중 어떤 식으로 리턴해주는게 더 나을까 생각했지만 가능한 API 요청의 수를 줄일 수 있으면 줄이는 게 낫다고 판단하여 RequestParameter로 ~~~?page=1 와 같이 파라미터로 여러번 요청해야 한다는 생각에 Map으로 전달했습니다.
Map의 key값은 기수, value는 해당 기수의 인원들을 담아두었습니다.

## 3. 메모

