### PR TITLE
#36 Feat: 댓글 기능

### DIFF
--- a/src/main/java/leets/weeth/domain/post/controller/CommentController.java
+++ b/src/main/java/leets/weeth/domain/post/controller/CommentController.java
@@ -1,7 +1,6 @@
 package leets.weeth.domain.post.controller;
 
 import leets.weeth.domain.post.dto.RequestCommentDTO;
-import leets.weeth.domain.post.dto.ResponseCommentDTO;
 import leets.weeth.domain.post.service.CommentService;
 import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.error.exception.custom.InvalidAccessException;
@@ -9,8 +8,6 @@ import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +17,8 @@ public class CommentController {
     private CommentService commentService;
     @PostMapping("")
     public CommonResponse<String> createComment(@PathVariable Long postId, @RequestBody RequestCommentDTO dto,
-                                         @CurrentUser Long userId) throws InvalidAccessException {
-        commentService.create(userId, postId, dto);
+                                         @CurrentUser Long userId) {
+        commentService.createComment(userId, postId, dto);
         return CommonResponse.createSuccess();
     }
 

--- a/src/main/java/leets/weeth/domain/post/controller/CommentController.java
+++ b/src/main/java/leets/weeth/domain/post/controller/CommentController.java
@@ -25,12 +25,6 @@ public class CommentController {
         return CommonResponse.createSuccess();
     }
 
-    @GetMapping()
-    public CommonResponse<List<ResponseCommentDTO>> getAllCommentsFromPost(@PathVariable Long postId){
-        List<ResponseCommentDTO> comments = commentService.getAllCommentsFromPost(postId);
-        return CommonResponse.createSuccess(comments);
-    }
-
     @PatchMapping("/{commentId}")
     public CommonResponse<String> updateComment(@PathVariable Long postId, @PathVariable Long commentId, @CurrentUser Long userId,
                                                 @RequestBody RequestCommentDTO dto) throws InvalidAccessException {

--- a/src/main/java/leets/weeth/domain/post/controller/CommentController.java
+++ b/src/main/java/leets/weeth/domain/post/controller/CommentController.java
@@ -3,30 +3,46 @@ package leets.weeth.domain.post.controller;
 import leets.weeth.domain.post.dto.RequestCommentDTO;
 import leets.weeth.domain.post.dto.ResponseCommentDTO;
 import leets.weeth.domain.post.service.CommentService;
+import leets.weeth.global.auth.annotation.CurrentUser;
+import leets.weeth.global.common.error.exception.custom.InvalidAccessException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/articles/{articleId}/comments")
+@RequestMapping("/posts/{postId}/comments")
 public class CommentController {
     @Autowired
     private CommentService commentService;
     @PostMapping()
-    public CommonResponse<String> create(@PathVariable Long articleId, @RequestBody RequestCommentDTO dto,
-                                         @AuthenticationPrincipal User user){
-        commentService.create(user.getUsername(), articleId, dto);
+    public CommonResponse<String> create(@PathVariable Long postId, @RequestBody RequestCommentDTO dto,
+                                         @CurrentUser Long userId){
+        commentService.create(userId, postId, dto);
         return CommonResponse.createSuccess();
     }
+
     @GetMapping()
-    public CommonResponse<List<ResponseCommentDTO>> show(@PathVariable Long articleId){
-        List<ResponseCommentDTO> comments = commentService.comments(articleId);
+    public CommonResponse<List<ResponseCommentDTO>> getAllCommentsFromPost(@PathVariable Long postId){
+        List<ResponseCommentDTO> comments = commentService.getAllCommentsFromPost(postId);
         return CommonResponse.createSuccess(comments);
     }
+
+    @PatchMapping("/{commentId}")
+    public CommonResponse<String> updateComment(@PathVariable Long postId, @PathVariable Long commentId, @CurrentUser Long userId,
+                                                @RequestBody RequestCommentDTO dto) throws InvalidAccessException {
+        commentService.updateComment(userId, postId, commentId, dto);
+        return CommonResponse.createSuccess();
+    }
+
+    @DeleteMapping("/{commentId}")
+    public CommonResponse<String> delete(@PathVariable Long commentId, @CurrentUser Long userId) throws InvalidAccessException {
+        commentService.delete(userId, commentId);
+        return CommonResponse.createSuccess();
+    }
+
+
 }

--- a/src/main/java/leets/weeth/domain/post/controller/CommentController.java
+++ b/src/main/java/leets/weeth/domain/post/controller/CommentController.java
@@ -18,9 +18,9 @@ import java.util.List;
 public class CommentController {
     @Autowired
     private CommentService commentService;
-    @PostMapping()
-    public CommonResponse<String> create(@PathVariable Long postId, @RequestBody RequestCommentDTO dto,
-                                         @CurrentUser Long userId){
+    @PostMapping("")
+    public CommonResponse<String> createComment(@PathVariable Long postId, @RequestBody RequestCommentDTO dto,
+                                         @CurrentUser Long userId) throws InvalidAccessException {
         commentService.create(userId, postId, dto);
         return CommonResponse.createSuccess();
     }
@@ -39,10 +39,9 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public CommonResponse<String> delete(@PathVariable Long commentId, @CurrentUser Long userId) throws InvalidAccessException {
+    public CommonResponse<String> deleteComment(@PathVariable Long commentId, @CurrentUser Long userId) throws InvalidAccessException {
         commentService.delete(userId, commentId);
         return CommonResponse.createSuccess();
     }
-
 
 }

--- a/src/main/java/leets/weeth/domain/post/dto/RequestCommentDTO.java
+++ b/src/main/java/leets/weeth/domain/post/dto/RequestCommentDTO.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 public class RequestCommentDTO {
-
+    private Long parentId;
     @NotBlank
     private String content;
 

--- a/src/main/java/leets/weeth/domain/post/dto/ResponseCommentDTO.java
+++ b/src/main/java/leets/weeth/domain/post/dto/ResponseCommentDTO.java
@@ -3,8 +3,9 @@ package leets.weeth.domain.post.dto;
 import jakarta.validation.constraints.NotBlank;
 import leets.weeth.domain.post.entity.Comment;
 import lombok.*;
-
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @AllArgsConstructor
@@ -17,6 +18,7 @@ public class ResponseCommentDTO {
     private String name;
     @NotBlank
     private String content;
+    private List<ResponseCommentDTO> children;
     private LocalDateTime time;
 
     public static ResponseCommentDTO createResponseCommentDto(Comment comment) {
@@ -25,6 +27,9 @@ public class ResponseCommentDTO {
                 .name(comment.getUser().getName())
                 .content(comment.getContent())
                 .time(comment.getTime())
+                .children(comment.getChildren().stream()
+                        .map(ResponseCommentDTO::createResponseCommentDto)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/leets/weeth/domain/post/dto/ResponseCommentDTO.java
+++ b/src/main/java/leets/weeth/domain/post/dto/ResponseCommentDTO.java
@@ -2,12 +2,11 @@ package leets.weeth.domain.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import leets.weeth.domain.post.entity.Comment;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -15,11 +14,17 @@ import java.time.LocalDateTime;
 public class ResponseCommentDTO {
     private Long id;
     @NotBlank
+    private String name;
+    @NotBlank
     private String content;
     private LocalDateTime time;
 
     public static ResponseCommentDTO createResponseCommentDto(Comment comment) {
-        return new ResponseCommentDTO(comment.getId(), comment.getContent(),
-                comment.getTime());
+        return ResponseCommentDTO.builder()
+                .id(comment.getId())
+                .name(comment.getUser().getName())
+                .content(comment.getContent())
+                .time(comment.getTime())
+                .build();
     }
 }

--- a/src/main/java/leets/weeth/domain/post/dto/ResponseCommentDTO.java
+++ b/src/main/java/leets/weeth/domain/post/dto/ResponseCommentDTO.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@ToString
 public class ResponseCommentDTO {
     private Long id;
     @NotBlank

--- a/src/main/java/leets/weeth/domain/post/dto/ResponsePostDTO.java
+++ b/src/main/java/leets/weeth/domain/post/dto/ResponsePostDTO.java
@@ -6,6 +6,7 @@ import leets.weeth.domain.post.entity.Post;
 import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Builder
@@ -21,8 +22,13 @@ public class ResponsePostDTO {
     private String title;
     @NotBlank
     private String content;
+    @NotBlank
     private LocalDateTime time;
     private List<File> fileUrls;
+    private List<ResponseCommentDTO> comments;
+    @NotBlank
+    private Long totalComments;
+
 
     public static ResponsePostDTO createResponsePostDTO(Post post) {
         return ResponsePostDTO.builder()
@@ -32,6 +38,11 @@ public class ResponsePostDTO {
                 .content(post.getContent())
                 .time(post.getTime())
                 .fileUrls(post.getFileUrls())
+                .comments(post.getParentComments()
+                        .stream()
+                        .map(ResponseCommentDTO::createResponseCommentDto)
+                        .collect(Collectors.toList()))
+                .totalComments(post.getTotalComments())
                 .build();
     }
 }

--- a/src/main/java/leets/weeth/domain/post/entity/Comment.java
+++ b/src/main/java/leets/weeth/domain/post/entity/Comment.java
@@ -41,13 +41,13 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
-    @OneToMany
+    @OneToMany(orphanRemoval = true)
     private List<Comment> children = new ArrayList<>();
 
     LocalDateTime time;
+
     public static Comment createComment(RequestCommentDTO dto, Post post, User user){
         return Comment.builder()
-                .id(null)
                 .post(post)
                 .user(user)
                 .content(dto.getContent())

--- a/src/main/java/leets/weeth/domain/post/entity/Comment.java
+++ b/src/main/java/leets/weeth/domain/post/entity/Comment.java
@@ -1,7 +1,6 @@
 package leets.weeth.domain.post.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import leets.weeth.domain.post.dto.RequestCommentDTO;
@@ -12,7 +11,6 @@ import org.hibernate.annotations.ColumnDefault;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import static jakarta.persistence.FetchType.LAZY;
 
 @Builder
 @AllArgsConstructor
@@ -29,6 +27,7 @@ public class Comment extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name="post_id")
+    @JsonBackReference
     private Post post;
 
     @ManyToOne
@@ -42,13 +41,7 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
-    @ManyToOne(fetch = LAZY)
-    @JsonManagedReference
-    @JoinColumn(name = "parent_id")
-    private Comment parent; //null일 경우 최상위 댓글
-
-    @JsonBackReference
-    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    @OneToMany
     private List<Comment> children = new ArrayList<>();
 
     LocalDateTime time;
@@ -59,7 +52,6 @@ public class Comment extends BaseEntity {
                 .user(user)
                 .content(dto.getContent())
                 .isDeleted(false)
-                .time(null)
                 .build();
     }
 
@@ -78,7 +70,7 @@ public class Comment extends BaseEntity {
         this.content = "삭제된 댓글입니다.";
     }
 
-    public void setParentComment(Comment parentComment) {
-        this.parent = parentComment;
+    public void addChild(Comment child) {
+        this.children.add(child);
     }
 }

--- a/src/main/java/leets/weeth/domain/post/entity/Comment.java
+++ b/src/main/java/leets/weeth/domain/post/entity/Comment.java
@@ -2,17 +2,15 @@ package leets.weeth.domain.post.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
+import leets.weeth.domain.file.entity.File;
 import leets.weeth.domain.post.dto.RequestCommentDTO;
+import leets.weeth.domain.post.dto.RequestPostDTO;
 import leets.weeth.domain.user.entity.User;
 import leets.weeth.global.common.entity.BaseEntity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-
+import lombok.*;
 import java.time.LocalDateTime;
 
-
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
@@ -34,19 +32,21 @@ public class Comment extends BaseEntity {
     private User user;
 
     @NotEmpty
-    @Column
     private String content;
+
     LocalDateTime time;
     public static Comment createComment(RequestCommentDTO dto, Post post, User user){
+        return Comment.builder()
+                .id(null)
+                .post(post)
+                .user(user)
+                .content(dto.getContent())
+                .time(null)
+                .build();
+    }
 
-        Comment newComment = new Comment(
-                null,
-                post,
-                user,
-                dto.getContent(),
-                null
-        );
-        return newComment;
+    public void updateComment(RequestCommentDTO dto) {
+        this.content = dto.getContent();
     }
 
     @PrePersist
@@ -54,6 +54,5 @@ public class Comment extends BaseEntity {
     public void setTime() {
         this.time = this.getModifiedAt() == null ? this.getCreatedAt() : this.getModifiedAt();
     }
-
 
 }

--- a/src/main/java/leets/weeth/domain/post/repository/CommentRepository.java
+++ b/src/main/java/leets/weeth/domain/post/repository/CommentRepository.java
@@ -3,7 +3,6 @@ package leets.weeth.domain.post.repository;
 import leets.weeth.domain.post.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {

--- a/src/main/java/leets/weeth/domain/post/repository/CommentRepository.java
+++ b/src/main/java/leets/weeth/domain/post/repository/CommentRepository.java
@@ -2,11 +2,7 @@ package leets.weeth.domain.post.repository;
 
 import leets.weeth.domain.post.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query(value = "SELECT * FROM comment WHERE post_id = :postId", nativeQuery = true)
-    List<Comment> findByPostId(Long postId);
 }

--- a/src/main/java/leets/weeth/domain/post/service/CommentService.java
+++ b/src/main/java/leets/weeth/domain/post/service/CommentService.java
@@ -92,10 +92,8 @@ public class CommentService {
         postRepository.save(currentPost);
     }
 
-    // 댓글의 부모를 찾는 메서드
+    // 댓글의 부모 찾기
     private Comment findParentComment(Long commentId) {
-        // 부모 댓글을 찾는 로직을 여기에 추가합니다.
-        // 예를 들어, 댓글의 자식 댓글을 모두 로드하여 부모를 찾을 수 있습니다.
         List<Comment> allComments = commentRepository.findAll();
         for (Comment comment : allComments) {
             if (comment.getChildren().stream().anyMatch(child -> child.getId().equals(commentId))) {

--- a/src/main/java/leets/weeth/domain/post/service/CommentService.java
+++ b/src/main/java/leets/weeth/domain/post/service/CommentService.java
@@ -9,35 +9,62 @@ import leets.weeth.domain.post.repository.CommentRepository;
 import leets.weeth.domain.post.repository.PostRepository;
 import leets.weeth.domain.user.entity.User;
 import leets.weeth.domain.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import leets.weeth.global.common.error.exception.custom.CommentNotFoundException;
+import leets.weeth.global.common.error.exception.custom.InvalidAccessException;
+import leets.weeth.global.common.error.exception.custom.PostNotFoundException;
+import leets.weeth.global.common.error.exception.custom.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 @Service
 public class CommentService {
-    @Autowired
-    private PostRepository postRepository;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
 
-    public List<ResponseCommentDTO> comments(Long articleId) {
-        return commentRepository.findByPostId(articleId)
+    public List<ResponseCommentDTO> getAllCommentsFromPost(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+        return commentRepository.findByPostId(postId)
                 .stream()
                 .map(ResponseCommentDTO::createResponseCommentDto)
                 .collect(Collectors.toList());
     }
+    //myComments
 
-    public void create(String email, Long articleId, RequestCommentDTO requestCommentDTO) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("failed to add post! no such user"));
-        Post targetPost = postRepository.findById(articleId).orElseThrow(()->new EntityNotFoundException("failed to add post! no such post"));
+    public void create(Long userId, Long postId, RequestCommentDTO requestCommentDTO) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        Post createdPost = postRepository.findById(postId).orElseThrow(()->new EntityNotFoundException("failed to add post! no such post"));
 
-        Comment newComment = Comment.createComment(requestCommentDTO, targetPost, user);
+        Comment newComment = Comment.createComment(requestCommentDTO, createdPost, user);
         commentRepository.save(newComment);
+    }
+
+    public void updateComment(Long userId, Long postId, Long commentId, RequestCommentDTO requestCommentDTO) throws InvalidAccessException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+        Comment editedComment = commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+        if(user.getId()!=editedComment.getUser().getId()){
+            throw new InvalidAccessException();
+        }
+        editedComment.updateComment(requestCommentDTO);
+        commentRepository.save(editedComment);
+    }
+
+    public void delete(Long userId, Long commentId) throws InvalidAccessException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        Comment deletedComment = commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+        if(user.getId()!=deletedComment.getUser().getId()){
+            throw new InvalidAccessException();
+        }
+        commentRepository.delete(deletedComment);
     }
 }

--- a/src/main/java/leets/weeth/domain/post/service/PostService.java
+++ b/src/main/java/leets/weeth/domain/post/service/PostService.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor

--- a/src/main/java/leets/weeth/global/common/error/exception/custom/CommentNotFoundException.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/custom/CommentNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.weeth.global.common.error.exception.custom;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class CommentNotFoundException extends EntityNotFoundException {
+    public CommentNotFoundException() {
+        super("존재하지 않는 댓글입니다.");
+    }
+}


### PR DESCRIPTION
## 1. 개발내용
### 댓글 및 대댓글
- [x] 댓글 및 대댓글 생성
- [x] 댓글 및 대댓글 읽기
- [x] 댓글 및 대댓글 수정
- [x] 댓글 및 대댓글 삭제

## 2. 구현 세부사항
- 댓글과 대댓글 기능 : 대댓글은 최대 1회 참조(단일 참조) 가능
- 댓글 내용은 텍스트만 포함 (제목 및 파일 첨부 불가)

## 3. 메모
- Comment의 List<Comment> children을 출력하려고 하면 순환참조 오류가 일어나는데 그 점을 제외하면 기능들은 작동됩니다
- 위의 이유 때문에 Parent를 없애고 단일참조 하도록 수정하였습니다
- 댓글이 삭제된 뒤 대댓글이 모두 삭제되었을 때 댓글까지 삭제하도록 수정
