### PR TITLE
#38 Fix: 유저 정보 수정 로직 오류

### DIFF
--- a/src/main/java/leets/weeth/domain/user/controller/UserController.java
+++ b/src/main/java/leets/weeth/domain/user/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
 
     @Operation(summary = "내 정보 수정")
     @PatchMapping
-    public CommonResponse<Void> update(@CurrentUser Long userId, @RequestBody UserDTO.Update dto) {
+    public CommonResponse<Void> update(@CurrentUser Long userId, @RequestBody @Valid UserDTO.Update dto) {
         userService.update(userId, dto);
         return CommonResponse.createSuccess();
     }

--- a/src/main/java/leets/weeth/domain/user/dto/UserDTO.java
+++ b/src/main/java/leets/weeth/domain/user/dto/UserDTO.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.user.entity.enums.Department;
 import leets.weeth.domain.user.entity.enums.Position;
 
+import java.util.List;
+
 public class UserDTO {
 
     public record SignUp (
@@ -35,7 +37,7 @@ public class UserDTO {
             String tel,
             Department department,
             String email,
-            Integer cardinal,
+            List<Integer> cardinals,
             Position position
     ) {}
 }

--- a/src/main/java/leets/weeth/domain/user/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/entity/User.java
@@ -2,7 +2,11 @@ package leets.weeth.domain.user.entity;
 
 import jakarta.persistence.*;
 import leets.weeth.domain.user.converter.CardinalListConverter;
-import leets.weeth.domain.user.entity.enums.*;
+import leets.weeth.domain.user.dto.UserDTO;
+import leets.weeth.domain.user.entity.enums.Department;
+import leets.weeth.domain.user.entity.enums.Position;
+import leets.weeth.domain.user.entity.enums.Role;
+import leets.weeth.domain.user.entity.enums.Status;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.*;
 
@@ -14,7 +18,6 @@ import java.util.List;
 @Table(name = "users")
 @AllArgsConstructor
 @Builder
-@ToString
 public class User extends BaseEntity {
 
     @Id
@@ -70,4 +73,14 @@ public class User extends BaseEntity {
     public boolean isInactive() {
         return this.status != Status.ACTIVE;
     }
+
+    public void update(UserDTO.Update dto) {
+        this.name = dto.name();
+        this.email = dto.email();
+        this.password = dto.password();
+        this.studentId = dto.studentId();
+        this.tel = dto.tel();
+        this.department = dto.department();
+    }
+
 }

--- a/src/main/java/leets/weeth/domain/user/entity/User.java
+++ b/src/main/java/leets/weeth/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import leets.weeth.domain.user.entity.enums.Role;
 import leets.weeth.domain.user.entity.enums.Status;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -74,10 +75,10 @@ public class User extends BaseEntity {
         return this.status != Status.ACTIVE;
     }
 
-    public void update(UserDTO.Update dto) {
+    public void update(UserDTO.Update dto, PasswordEncoder passwordEncoder) {
         this.name = dto.name();
         this.email = dto.email();
-        this.password = dto.password();
+        this.password = passwordEncoder.encode(dto.password());
         this.studentId = dto.studentId();
         this.tel = dto.tel();
         this.department = dto.department();

--- a/src/main/java/leets/weeth/domain/user/mapper/UserMapper.java
+++ b/src/main/java/leets/weeth/domain/user/mapper/UserMapper.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserMapper {
-    // 수정: 모든 mapper 어노테이션 매핑 최소화
+
     @Mappings({
             @Mapping(target = "cardinals", expression = "java( java.util.List.of(dto.cardinal()) )"),
             @Mapping(target = "password", expression = "java( passwordEncoder.encode(dto.password()) )")
@@ -16,6 +16,5 @@ public interface UserMapper {
 
     UserDTO.Response to(User user);
 
-    User update(Long userId, UserDTO.Update dto);
 }
 

--- a/src/main/java/leets/weeth/domain/user/service/UserService.java
+++ b/src/main/java/leets/weeth/domain/user/service/UserService.java
@@ -73,8 +73,11 @@ public class UserService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    @Transactional
     public void update(Long userId, UserDTO.Update dto) {
-        User user = mapper.update(userId, dto);
-        userRepository.save(user);
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        user.update(dto);
     }
 }

--- a/src/main/java/leets/weeth/domain/user/service/UserService.java
+++ b/src/main/java/leets/weeth/domain/user/service/UserService.java
@@ -78,6 +78,6 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        user.update(dto);
+        user.update(dto, passwordEncoder);
     }
 }

--- a/src/main/java/leets/weeth/global/common/error/exception/ExceptionType.java
+++ b/src/main/java/leets/weeth/global/common/error/exception/ExceptionType.java
@@ -18,6 +18,9 @@ public enum ExceptionType {
     BUSINESS_LOGIC_ERROR(HttpStatus.BAD_REQUEST, BusinessLogicException.class),
     TYPE_NOT_MATCH(HttpStatus.BAD_REQUEST, TypeNotMatchException.class),
     USER_NOT_MATCH(HttpStatus.BAD_REQUEST, UserNotMatchException.class),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, UserNotFoundException.class),
+    USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, UserExistsException.class),
+    INVALID_ACCESS_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidAccessException.class),
     NOTICE_NOT_FOUND(HttpStatus.BAD_REQUEST, NoticeNotFoundException.class),
     EVENT_NOT_FOUND(HttpStatus.BAD_REQUEST, EventNotFoundException.class),
     INVALID_INPUT_DATE(HttpStatus.BAD_REQUEST, InvalidInputDateException.class);


### PR DESCRIPTION
## 1. 개발내용
Fix: 유저 정보 수정 로직 오류

<br>

## 2. 구현 세부사항
mapper 클래스에서 update -> 엔티티 메서드

<br>

## 3. 메모

```java
void update(UserDTO.Update dto, @MappingTarget User user);
```
위 mapper의 공식 문서 상에 나오는 메서드 템플릿은 User에 @Setter가 설정돼야 하는데
엔티티의 무결성을 위해선 @Setter를 피하는 게 더 나은 방법이라고 생각함 ,,
하지만 종종 실무에서 엔티티가 매우 크고, 엔티티 메서드에 업데이트 로직이 많은 경우, @Setter로 관리하는 것이 오버헤드가 더 적다고 판단하여
사용할 때도 있음. (블로그에서 그랬음 ㅋㅋ)
근데 우리 서비스는 그정도는 아니라고 해서 네시간 가량의 삽질해서 알게 된 방법을 눈물을 머금고 포기했다 ,,

심신미약이었던 내 삽질을 
ㄱ
ㅡ
ㄴ표가 해결함 ㅋㅋ
샤랴웃 투 이근표