### PR TITLE
#40 Feat: 공지사항에 파일 첨부 기능 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/event/controller/EventController.java
+++ b/src/main/java/leets/weeth/domain/event/controller/EventController.java
@@ -12,7 +12,6 @@ import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -29,25 +28,21 @@ public class EventController {
     private final EventService eventService;
 
     @Operation(summary = "일정 생성", description = "관리자가 일정을 등록합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
-    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
+    public CommonResponse<String> createEvent(@RequestBody @Valid RequestEvent requestEvent,
+                                              @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
         eventService.createEvent(requestEvent, userId);
         return CommonResponse.createSuccess(EVENT_CREATED_SUCCESS.getMessage());
     }
 
-
     @Operation(summary = "일정 상세 조회", description = "사용자가 일정의 세부사항을 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    @GetMapping("/{id}")
-    public CommonResponse<ResponseEvent> getEvent(@PathVariable Long id) {
-        ResponseEvent responseEvent = eventService.getEventById(id);
+    @GetMapping("/{eventId}")
+    public CommonResponse<ResponseEvent> getEvent(@PathVariable Long eventId) {
+        ResponseEvent responseEvent = eventService.getEventById(eventId);
         return CommonResponse.createSuccess(responseEvent);
     }
 
-
     @Operation(summary = "기간 일정 조회", description = "사용자가 일정 기간의 세부사항을 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public CommonResponse<List<ResponseEvent>> getEvents(
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
@@ -58,29 +53,25 @@ public class EventController {
     }
 
     @Operation(summary = "년도별 일정 조회", description = "사용자가 1년 단위로 일정을 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    @GetMapping("/year") //requestParam으로 해보기
+    @GetMapping("/year")
     public CommonResponse<Map<Integer, List<ResponseEvent>>> getYearEvents(@RequestParam int year) throws BusinessLogicException {
         Map<Integer, List<ResponseEvent>> responseEvents = eventService.getEventsOfYear(year);
         return CommonResponse.createSuccess(responseEvents);
     }
 
-
     @Operation(summary = "일정 수정", description = "관리자가 일정을 수정합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    @PatchMapping("/{id}")
-    public CommonResponse<String> updateEvent(@PathVariable Long id, @RequestBody RequestEvent requestEvent, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
-        eventService.updateEvent(id, requestEvent, userId);
+    @PatchMapping("/{eventId}")
+    public CommonResponse<String> updateEvent(@PathVariable Long eventId, @RequestBody RequestEvent requestEvent,
+                                              @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
+        eventService.updateEvent(eventId, requestEvent, userId);
         return CommonResponse.createSuccess(EVENT_UPDATED_SUCCESS.getMessage());
     }
 
-
     @Operation(summary = "일정 삭제", description = "관리자가 일정을 삭제합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/{id}")
-    public CommonResponse<String> deleteEvent(@PathVariable Long id, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
-        eventService.deleteEvent(id, userId);
+    @DeleteMapping("/{eventId}")
+    public CommonResponse<String> deleteEvent(@PathVariable Long eventId,
+                                              @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
+        eventService.deleteEvent(eventId, userId);
         return CommonResponse.createSuccess(EVENT_DELETED_SUCCESS.getMessage());
     }
-
 }

--- a/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
+++ b/src/main/java/leets/weeth/domain/event/dto/ResponseEvent.java
@@ -14,8 +14,8 @@ public record ResponseEvent (
         String location,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime,
-        LocalDateTime created_at,
-        LocalDateTime modified_at,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
         String userName,
         Type type
 ) {}

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -3,12 +3,15 @@ package leets.weeth.domain.event.entity;
 import jakarta.persistence.*;
 import leets.weeth.domain.event.dto.RequestEvent;
 import leets.weeth.domain.event.entity.enums.Type;
+import leets.weeth.domain.file.entity.File;
 import leets.weeth.domain.notice.dto.RequestNotice;
 import leets.weeth.domain.user.entity.User;
 import leets.weeth.global.common.entity.BaseEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Entity
@@ -37,11 +40,12 @@ public class Event extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Type type;
 
+    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<File> fileUrls = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable=false)
     private User user;
-
-
 
     // 일정 수정을 위한 메소드
     public void updateFromEventDto(RequestEvent dto) {
@@ -54,10 +58,14 @@ public class Event extends BaseEntity {
     }
 
     // 공지 수정을 위한 메소드
-    public void updateFromNoticeDto(RequestNotice dto, LocalDateTime now) {
+    public void updateFromNoticeDto(RequestNotice dto, List<File> fileUrlList, LocalDateTime now) {
         Optional.ofNullable(dto.title()).ifPresent(title -> this.title = title);
         Optional.ofNullable(dto.content()).ifPresent(content -> this.content = content);
-        Optional.ofNullable(now).ifPresent(startDateTime -> this.startDateTime = now);
-        Optional.ofNullable(now).ifPresent(endDateTime -> this.endDateTime = now);
+        Optional.ofNullable(fileUrlList).ifPresent(files -> {
+            this.fileUrls.clear();
+            this.fileUrls.addAll(files);
+        });
+        this.startDateTime = now;
+        this.endDateTime = now;
     }
 }

--- a/src/main/java/leets/weeth/domain/event/entity/Event.java
+++ b/src/main/java/leets/weeth/domain/event/entity/Event.java
@@ -37,37 +37,11 @@ public class Event extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Type type;
 
-    // 파일관련
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable=false)
     private User user;
 
-    // 일정 생성을 위한 정적 팩토리 메서드
-    public static Event fromEventDto(RequestEvent dto, User user) {
-        return Event.builder()
-                .title(dto.title())
-                .content(dto.content())
-                .location(dto.location())
-                .startDateTime(dto.startDateTime())
-                .endDateTime(dto.endDateTime())
-                .type(dto.type())
-                .user(user)
-                .build();
-    }
 
-    // 공지사항 생성을 위한 정적 팩토리 메서드
-    public static Event fromNoticeDto(RequestNotice dto, Type type, User user, LocalDateTime now) {
-        return Event.builder()
-                .title(dto.title())
-                .content(dto.content())
-                .location(null)
-                .startDateTime(now)
-                .endDateTime(now)
-                .type(type)
-                .user(user)
-                .build();
-    }
 
     // 일정 수정을 위한 메소드
     public void updateFromEventDto(RequestEvent dto) {

--- a/src/main/java/leets/weeth/domain/event/mapper/EventMapper.java
+++ b/src/main/java/leets/weeth/domain/event/mapper/EventMapper.java
@@ -1,23 +1,23 @@
 package leets.weeth.domain.event.mapper;
 
+import leets.weeth.domain.event.dto.RequestEvent;
 import leets.weeth.domain.event.dto.ResponseEvent;
 import leets.weeth.domain.event.entity.Event;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import leets.weeth.domain.user.entity.User;
+import org.mapstruct.*;
 
-@Mapper(componentModel = "spring")
-public interface EventMapper {
-    EventMapper INSTANCE = Mappers.getMapper(EventMapper.class);
-
-//    Event fromDto(RequestEvent requestEvent);
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)public interface EventMapper {
 
     @Mappings({
             @Mapping(source = "user.name", target = "userName"),
-            @Mapping(source = "createdAt", target = "created_at"),
-            @Mapping(source = "modifiedAt", target = "modified_at"),
+            @Mapping(source = "createdAt", target = "createdAt"),
+            @Mapping(source = "modifiedAt", target = "modifiedAt"),
     })
-    ResponseEvent toDto(Event event);
+    ResponseEvent toEventDto(Event event);
 
+    @Mappings({
+            @Mapping(source = "user", target = "user"),
+            @Mapping(target = "id", ignore = true)
+    })
+    Event fromEventDto(RequestEvent dto, User user);
 }

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -34,7 +34,7 @@ public class EventService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        eventRepository.save(Event.fromEventDto(requestEvent, user));
+        eventRepository.save(eventMapper.fromEventDto(requestEvent, user));
     }
 
 
@@ -45,7 +45,7 @@ public class EventService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(EventNotFoundException::new);
 
-        return eventMapper.toDto(event);
+        return eventMapper.toEventDto(event);
     }
 
     // 기간 별 일정 조회
@@ -56,7 +56,7 @@ public class EventService {
 
         List<Event> events = eventRepository.findByStartDateTimeBetween(startDate, endDate);
         return events.stream()
-                .map(eventMapper::toDto)
+                .map(eventMapper::toEventDto)
                 .toList();
     }
 
@@ -78,7 +78,7 @@ public class EventService {
                 int month = eventStart.getMonthValue();
                 eventsByMonth
                         .computeIfAbsent(month, k -> new ArrayList<>())
-                        .add(eventMapper.toDto(event));
+                        .add(eventMapper.toEventDto(event));
                 // 한달씩 증가
                 eventStart = eventStart.plusMonths(1).withDayOfMonth(1)
                         .withHour(0).withMinute(0).withSecond(0).withNano(0);

--- a/src/main/java/leets/weeth/domain/event/service/EventService.java
+++ b/src/main/java/leets/weeth/domain/event/service/EventService.java
@@ -112,7 +112,7 @@ public class EventService {
     }
 
     // 검색된 event가 EVENT 인지 확인, 맞으면 생성한 사용자와 현재 사용자가 동일한지 확인
-    private void validateEventOwner(Event event , Long userId) throws BusinessLogicException {
+    private void validateEventOwner(Event event, Long userId) throws BusinessLogicException {
         // 해당 일정이 EVENT 인지 확인 -> 출석은 이후 따로 구현할 예정
         // 출석은 여기서 수정해도 되지 않나..? -> 팀원들 얘기 들어보기
         if(!event.getType().equals(Type.EVENT)){

--- a/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import leets.weeth.domain.notice.dto.RequestNotice;
 import leets.weeth.domain.notice.dto.ResponseNotice;
 import leets.weeth.domain.notice.service.NoticeService;
+import leets.weeth.domain.post.dto.RequestPostDTO;
 import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.error.exception.custom.BusinessLogicException;
 import leets.weeth.global.common.error.exception.custom.TypeNotMatchException;
@@ -14,6 +15,7 @@ import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -22,7 +24,7 @@ import static leets.weeth.domain.notice.enums.ResponseMessage.*;
 @Tag(name = "NoticeController", description = "공지 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("notice")
+@RequestMapping("/notice")
 public class NoticeController {
     private final NoticeService noticeService;
 
@@ -30,8 +32,10 @@ public class NoticeController {
     @Operation(summary = "공지 생성", description = "관리자가 공지사항을 등록합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
-    public CommonResponse<String> createNotice(@RequestBody @Valid RequestNotice requestNotice, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
-        noticeService.createNotice(requestNotice, userId);
+    public CommonResponse<String> createNotice(@RequestPart(value = "requestNotice") @Valid RequestNotice requestNotice,
+                                               @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                                               @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
+        noticeService.createNotice(requestNotice, files, userId);
         return CommonResponse.createSuccess(NOTICE_CREATED_SUCCESS.getMessage());
     }
 
@@ -57,8 +61,11 @@ public class NoticeController {
     @Operation(summary = "공지사항 수정", description = "관리자가 공지사항을 수정합니다.")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PatchMapping("/{id}")
-    public CommonResponse<String> updateNotice(@PathVariable Long id, @RequestBody RequestNotice requestNotice, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
-        noticeService.updateNotice(id, requestNotice, userId);
+    public CommonResponse<String> updateNotice(@PathVariable Long id,
+                                               @RequestPart(value = "requestNotice") @Valid RequestNotice requestNotice,
+                                               @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                                               @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
+        noticeService.updateNotice(id, requestNotice,files, userId);
         return CommonResponse.createSuccess(NOTICE_UPDATED_SUCCESS.getMessage());
     }
 

--- a/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
@@ -40,9 +40,9 @@ public class NoticeController {
 
     // 공지사항 세부 조회
     @Operation(summary = "공지사항 상세 조회", description = "사용자가 공지사항을 조회합니다.")
-    @GetMapping("/{id}")
-    public CommonResponse<ResponseNotice> getNotice(@PathVariable Long id) throws TypeNotMatchException {
-        ResponseNotice responseNotice = noticeService.getNoticeById(id);
+    @GetMapping("/{noticeId}")
+    public CommonResponse<ResponseNotice> getNotice(@PathVariable Long noticeId) throws TypeNotMatchException {
+        ResponseNotice responseNotice = noticeService.getNoticeById(noticeId);
         return CommonResponse.createSuccess(responseNotice);
     }
 
@@ -56,20 +56,20 @@ public class NoticeController {
 
     // 공지사항 수정
     @Operation(summary = "공지사항 수정", description = "관리자가 공지사항을 수정합니다.")
-    @PatchMapping("/{id}")
-    public CommonResponse<String> updateNotice(@PathVariable Long id,
-                                               @RequestPart(value = "requestNotice") @Valid RequestNotice requestNotice,
+    @PatchMapping("/{noticeId}")
+    public CommonResponse<String> updateNotice(@RequestPart(value = "requestNotice") @Valid RequestNotice requestNotice,
                                                @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                                               @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
-        noticeService.updateNotice(id, requestNotice,files, userId);
+                                               @Parameter(hidden = true) @CurrentUser Long userId,
+                                               @PathVariable Long noticeId) throws BusinessLogicException {
+        noticeService.updateNotice(requestNotice,files, userId, noticeId);
         return CommonResponse.createSuccess(NOTICE_UPDATED_SUCCESS.getMessage());
     }
 
     // 공지사항 삭제
     @Operation(summary = "공지사항 삭제", description = "관리자가 공지사항을 삭제합니다.")
-    @DeleteMapping("/{id}")
-    public CommonResponse<String> deleteNotice(@PathVariable Long id, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
-        noticeService.deleteNotice(id, userId);
+    @DeleteMapping("/{noticeId}")
+    public CommonResponse<String> deleteNotice(@PathVariable Long noticeId, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
+        noticeService.deleteNotice(noticeId, userId);
         return CommonResponse.createSuccess(NOTICE_DELETED_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
@@ -30,7 +30,6 @@ public class NoticeController {
 
     // 공지사항 생성
     @Operation(summary = "공지 생성", description = "관리자가 공지사항을 등록합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
     public CommonResponse<String> createNotice(@RequestPart(value = "requestNotice") @Valid RequestNotice requestNotice,
                                                @RequestPart(value = "files", required = false) List<MultipartFile> files,
@@ -41,7 +40,6 @@ public class NoticeController {
 
     // 공지사항 세부 조회
     @Operation(summary = "공지사항 상세 조회", description = "사용자가 공지사항을 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @GetMapping("/{id}")
     public CommonResponse<ResponseNotice> getNotice(@PathVariable Long id) throws TypeNotMatchException {
         ResponseNotice responseNotice = noticeService.getNoticeById(id);
@@ -50,7 +48,6 @@ public class NoticeController {
 
     // 공지사항 전부
     @Operation(summary = "전체 공지사항 조회", description = "사용자가 전체 공지사항을 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @GetMapping("/")
     public CommonResponse<List<ResponseNotice>> getAllNotices() {
         List<ResponseNotice> responseNotices = noticeService.getNotices();
@@ -59,7 +56,6 @@ public class NoticeController {
 
     // 공지사항 수정
     @Operation(summary = "공지사항 수정", description = "관리자가 공지사항을 수정합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @PatchMapping("/{id}")
     public CommonResponse<String> updateNotice(@PathVariable Long id,
                                                @RequestPart(value = "requestNotice") @Valid RequestNotice requestNotice,
@@ -71,7 +67,6 @@ public class NoticeController {
 
     // 공지사항 삭제
     @Operation(summary = "공지사항 삭제", description = "관리자가 공지사항을 삭제합니다.")
-    @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
     public CommonResponse<String> deleteNotice(@PathVariable Long id, @Parameter(hidden = true) @CurrentUser Long userId) throws BusinessLogicException {
         noticeService.deleteNotice(id, userId);

--- a/src/main/java/leets/weeth/domain/notice/dto/ResponseNotice.java
+++ b/src/main/java/leets/weeth/domain/notice/dto/ResponseNotice.java
@@ -10,8 +10,8 @@ public record ResponseNotice(
         Long id,
         String title,
         String content,
-        LocalDateTime created_at,
-        LocalDateTime modified_at,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
         String userName,
         Type type
         // 파일관련

--- a/src/main/java/leets/weeth/domain/notice/dto/ResponseNotice.java
+++ b/src/main/java/leets/weeth/domain/notice/dto/ResponseNotice.java
@@ -1,9 +1,11 @@
 package leets.weeth.domain.notice.dto;
 
 import leets.weeth.domain.event.entity.enums.Type;
+import leets.weeth.domain.file.entity.File;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record ResponseNotice(
@@ -13,8 +15,8 @@ public record ResponseNotice(
         LocalDateTime createdAt,
         LocalDateTime modifiedAt,
         String userName,
-        Type type
-        // 파일관련
+        Type type,
+        List<File> fileUrls
 
 ) {
 }

--- a/src/main/java/leets/weeth/domain/notice/dto/ResponseNotice.java
+++ b/src/main/java/leets/weeth/domain/notice/dto/ResponseNotice.java
@@ -17,6 +17,5 @@ public record ResponseNotice(
         String userName,
         Type type,
         List<File> fileUrls
-
 ) {
 }

--- a/src/main/java/leets/weeth/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/notice/mapper/NoticeMapper.java
@@ -1,10 +1,13 @@
 package leets.weeth.domain.notice.mapper;
 
 import leets.weeth.domain.event.entity.Event;
+import leets.weeth.domain.file.entity.File;
 import leets.weeth.domain.notice.dto.RequestNotice;
 import leets.weeth.domain.notice.dto.ResponseNotice;
 import leets.weeth.domain.user.entity.User;
 import org.mapstruct.*;
+
+import java.util.List;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface NoticeMapper {
@@ -23,5 +26,5 @@ public interface NoticeMapper {
             @Mapping(target = "type", expression = "java( leets.weeth.domain.event.entity.enums.Type.NOTICE)"),
             @Mapping(target = "id", ignore = true)
     })
-    Event fromNoticeDto(RequestNotice dto, User user);
+    Event fromNoticeDto(RequestNotice dto, List<File> fileUrls, User user);
 }

--- a/src/main/java/leets/weeth/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/notice/mapper/NoticeMapper.java
@@ -1,21 +1,27 @@
 package leets.weeth.domain.notice.mapper;
 
 import leets.weeth.domain.event.entity.Event;
+import leets.weeth.domain.notice.dto.RequestNotice;
 import leets.weeth.domain.notice.dto.ResponseNotice;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import leets.weeth.domain.user.entity.User;
+import org.mapstruct.*;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface NoticeMapper {
-    NoticeMapper INSTANCE = Mappers.getMapper(NoticeMapper.class);
-
     @Mappings({
             @Mapping(source = "user.name", target = "userName"),
-            @Mapping(source = "createdAt", target = "created_at"),
-            @Mapping(source = "modifiedAt", target = "modified_at"),
+            @Mapping(source = "createdAt", target = "createdAt"),
+            @Mapping(source = "modifiedAt", target = "modifiedAt"),
     })
-    ResponseNotice toDto(Event event);
+    ResponseNotice toNoticeDto(Event event);
 
+    @Mappings({
+            @Mapping(source = "user", target = "user"),
+            @Mapping(target = "location", expression = "java(null)"),
+            @Mapping(target = "startDateTime", expression = "java( java.time.LocalDateTime.now())"),
+            @Mapping(target = "endDateTime", expression = "java( java.time.LocalDateTime.now())"),
+            @Mapping(target = "type", expression = "java( leets.weeth.domain.event.entity.enums.Type.NOTICE)"),
+            @Mapping(target = "id", ignore = true)
+    })
+    Event fromNoticeDto(RequestNotice dto, User user);
 }

--- a/src/main/java/leets/weeth/domain/notice/service/NoticeService.java
+++ b/src/main/java/leets/weeth/domain/notice/service/NoticeService.java
@@ -33,7 +33,7 @@ public class NoticeService {
         // 일정에 저장시 startDateTime과 endDateTime을 현재 시간으로 저장
         LocalDateTime now = LocalDateTime.now();
         // 상태는 NOTICE로 저장
-        eventRepository.save(Event.fromNoticeDto(requestNotice, Type.NOTICE, user, now));
+        eventRepository.save(noticeMapper.fromNoticeDto(requestNotice, user));
     }
 
     // 모든 공지사항 조회
@@ -43,7 +43,7 @@ public class NoticeService {
         List<Event> events = eventRepository.findAllByType(Type.NOTICE, Sort.by(Sort.Direction.ASC, "id"));
 
         return events.stream()
-                .map(noticeMapper::toDto)
+                .map(noticeMapper::toNoticeDto)
                 .toList();
     }
 
@@ -54,7 +54,7 @@ public class NoticeService {
         Event event = eventRepository.findByIdAndType(id, Type.NOTICE)
                 .orElseThrow(TypeNotMatchException::new);//예외 수정 statusNotMatch
 
-        return noticeMapper.toDto(event);
+        return noticeMapper.toNoticeDto(event);
     }
 
     // 공지 수정

--- a/src/main/java/leets/weeth/domain/notice/service/NoticeService.java
+++ b/src/main/java/leets/weeth/domain/notice/service/NoticeService.java
@@ -51,11 +51,14 @@ public class NoticeService {
 
     // 공지 상세 조회
     @Transactional(readOnly = true)
-    public ResponseNotice getNoticeById(Long id) throws TypeNotMatchException {
-        // getNotice로 온 요청엔 공지사항 게시판에서 온 요청이라 가정. NOTICE만 반환
-        Event event = eventRepository.findByIdAndType(id, Type.NOTICE)
-                .orElseThrow(TypeNotMatchException::new);//예외 수정 statusNotMatch
-
+    public ResponseNotice getNoticeById(Long noticeId) throws TypeNotMatchException {
+        // 해당 일정이 존재하는지 먼저 확인
+        Event event = eventRepository.findById(noticeId)
+                .orElseThrow(NoticeNotFoundException::new);
+        // 존재한다면 type이 NOTICE 인지 확인
+        if(!event.getType().equals(Type.NOTICE)){
+            throw new TypeNotMatchException();
+        }
         return noticeMapper.toNoticeDto(event);
     }
 


### PR DESCRIPTION
## 1. 개발내용
- 공지사항에 파일 첨부 기능 추가
- 그로 인한 dto 변경 및 세부 수정
- 정적 팩토리 메서드 삭제 -> mapper로 관리
- 글로벌하게 경로 인증을 하기로 했으므로 컨트롤러 단위에서 user, admin을 확인하는 @PreAuthorize 어노테이션 삭제
## 2. 구현 세부사항
- 공지사항과 일정은 통합해서 저장되기 때문에 Event 엔티티에 fileUrls 추가
- 공지사항 생성, 조회, 수정 시 파일 첨부 관련 로직이 포함되게 구현

<details>
<summary>공지사항에 파일 첨부 요청 </summary>
<img width="1137" alt="image" src=https://github.com/user-attachments/assets/a5c2d677-bd81-4507-9801-090db1152fcc>
</details>

<details>
<summary>공지사항에 파일 조회 </summary>
<img width="1137" alt="image" src=https://github.com/user-attachments/assets/12375f65-cef9-47a1-99b3-2310fc9c31de>
</details>

<details>
<summary>공지사항에 파일 조회 </summary>
<img width="1137" alt="image" src=https://github.com/user-attachments/assets/4aa12958-5f32-4544-b275-0d5193535708>
</details>

## 3. 메모
- 공지와 일정이 같이 저장되고, 일정에서 들어오는 요청과 공지에서 들어오는 요청을 다르게 관리해야하기 때문에 구분하여 처리하는 것에 집중하였습니다.
- RUD시 type 매칭과 user 매칭을 통해 적절한 요청만 수행될 수 있도록 구현하려고 노력했습니당
- 파일 첨부 관련해서 문제가 있는지 검토 부탁드려요!
