### PR TITLE
#77 Feat: 최근 공지사항 15개 조회 기능

### DIFF
--- a/src/main/java/leets/weeth/domain/event/repository/EventRepository.java
+++ b/src/main/java/leets/weeth/domain/event/repository/EventRepository.java
@@ -2,6 +2,7 @@ package leets.weeth.domain.event.repository;
 
 import leets.weeth.domain.event.entity.Event;
 import leets.weeth.domain.event.entity.enums.Type;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +25,10 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Optional<Event> findByTypeAndStartDateTimeIsBeforeAndEndDateTimeIsAfter(Type type, LocalDateTime start, LocalDateTime end);
 
     List<Event> findAllByTypeAndCardinal(Type type, Integer cardinal);
+
+    @Query("SELECT MAX(e.id) FROM Event e WHERE e.type = :type")
+    Long findMaxNoticeId(@Param("type") Type type);
+
+    @Query("SELECT e FROM Event e WHERE e.id < :lastNoticeId AND e.type = :type ORDER BY e.id DESC")
+    List<Event> findRecentNoticesBytype(@Param("lastNoticeId") Long lastNoticeId, @Param("type") Type type, Pageable pageable);
 }

--- a/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
+++ b/src/main/java/leets/weeth/domain/notice/controller/NoticeController.java
@@ -4,13 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.weeth.domain.notice.dto.ResponseNotice;
 import leets.weeth.domain.notice.service.NoticeService;
+import leets.weeth.global.common.error.exception.custom.InvalidAccessException;
 import leets.weeth.global.common.error.exception.custom.TypeNotMatchException;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -32,6 +30,13 @@ public class NoticeController {
     @GetMapping("")
     public CommonResponse<List<ResponseNotice>> getAllNotices() {
         List<ResponseNotice> responseNotices = noticeService.getAllNotices();
+        return CommonResponse.createSuccess(responseNotices);
+    }
+
+    @Operation(summary = "공지사항 15개 조회", description = "사용자가 공지사항 15개를 조회합니다.")
+    @GetMapping("/load")
+    public CommonResponse<List<ResponseNotice>> loadNotices (@RequestParam(required = false) Long lastNoticeId) throws InvalidAccessException {
+        List<ResponseNotice> responseNotices = noticeService.loadNotices(lastNoticeId);
         return CommonResponse.createSuccess(responseNotices);
     }
 }


### PR DESCRIPTION
## 1. 개발내용
- [x] 공지사항 15개 조회하기

## 2. 구현 세부사항
현재 로딩된 공지사항이 없다(처음으로 요청 보낼때)면 가장 최근 공지사항 15개 조회
만약 이미 조회한 공지사항이 있고 추가로 조회를 원하면 가장 마지막에 있는 notice의 id를 파라미터로 받아와
15개를 조회하게 됩니다
